### PR TITLE
Fix missing file after cp

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -8,6 +8,7 @@ process {
     stageOutMode = 'rsync'
     tag = { "$sid" }
     afterScript = 'sleep 1'
+    containerOptions = "--user \$(id -u):\$(id -g)"
 }
 
 cleanup = true


### PR DESCRIPTION
cp operations (e.g. in the Copy_t1_to_orig stage) seem to keep the original file permissions which seems to cause some problems on machines where the user doesn't have access to read/write/exectute on some files, preventing nextflow to sync those files in the final nextflow staging process. This PR fixes that issue.